### PR TITLE
fix small lang typo

### DIFF
--- a/src/main/resources/assets/chisel/lang/en_US.lang
+++ b/src/main/resources/assets/chisel/lang/en_US.lang
@@ -16,7 +16,7 @@ item.chisel.chisel.desc.modes=Has multiple modes for chiseling.
 
 item.chisel.chisel_diamond.name=Diamond Chisel
 item.chisel.chisel_obsidian.name=Obsidian Chisel
-item.chisel.chisel_netherstar.name=Bedrockium Сhisel
+item.chisel.chisel_netherstar.name=Bedrockium Chisel
 
 item.ballMoss.name=Ball O' Moss
 item.ballMoss.desc=Right-Click to throw. This will turn Cobblestone to Moss Stone on impact.


### PR DESCRIPTION
It was the Cyrillic letter "C". I noticed due to the fact that in 1.7.10 the Cyrillic alphabet is displayed small. Altogether a miracle.

![2022-01-24_03-34](https://user-images.githubusercontent.com/64635280/150702703-af9bdce0-d0ea-4c76-9563-989301b9fba0.png)

