### PR TITLE
Fix broken recipes for hempcrete and hempcrete powder

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -1592,7 +1592,7 @@ public enum Features {
         }
     },
 
-    Hempcrete {
+    HEMPCRETE {
 
         @Override
         void addBlocks() {
@@ -1625,7 +1625,7 @@ public enum Features {
         }
     },
 
-    Hempcrete_Sand {
+    HEMPCRETE_SAND {
 
         @Override
         void addBlocks() {

--- a/src/main/java/team/chisel/init/ChiselBlocks.java
+++ b/src/main/java/team/chisel/init/ChiselBlocks.java
@@ -104,13 +104,13 @@ public final class ChiselBlocks {
     // Holidays
     public static final BlockCarvable valentines = null;
     public static final BlockPresent present = null;
-    public static BlockCarvableSand hempcretesand = null;
+	
+	// Jimbno additions
+    public static final BlockCarvableSand hempcretesand = null;
     public static final BlockCarvable nucrete = null;
     public static final BlockCarvable neonite = null;
     public static final BlockCarvable glotek = null;
-
     public static final BlockCarvable hempcrete = null;
-
     public static final BlockCarvable sveltstone = null;
     public static final BlockCarvable cubit = null;
 

--- a/src/main/java/team/chisel/init/ChiselBlocks.java
+++ b/src/main/java/team/chisel/init/ChiselBlocks.java
@@ -104,8 +104,8 @@ public final class ChiselBlocks {
     // Holidays
     public static final BlockCarvable valentines = null;
     public static final BlockPresent present = null;
-	
-	// Jimbno additions
+
+    // Jimbno additions
     public static final BlockCarvableSand hempcretesand = null;
     public static final BlockCarvable nucrete = null;
     public static final BlockCarvable neonite = null;


### PR DESCRIPTION
Fix broken recipes for hempcrete and hempcrete powder.

They caused pack crashes from nulls until nei_custom_diagram got extra null checks.

was just a missing 'final', the rest is cosmetic.