### PR TITLE
Change hempcrete recipe from fern to wheat to actually be automatable

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -1654,7 +1654,7 @@ public enum Features {
                     '*',
                     new ItemStack(Blocks.sand, 1),
                     'X',
-                    new ItemStack(Blocks.tallgrass, 1, 2));
+                    new ItemStack(Items.wheat, 1, 2));
         }
     },
 


### PR DESCRIPTION
Changes the recipe from 8 Sand + 1 Fern to 8 Sand + 1 Wheat, thematically the same but Fern is basically impossible to automate.