### PR TITLE
Fix broken recipe for hempcrete powder (yes, again!)

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -1646,15 +1646,17 @@ public enum Features {
 
         @Override
         void addRecipes() {
-            GameRegistry.addRecipe(
-                    new ItemStack(ChiselBlocks.hempcretesand, 8, 0),
-                    "***",
-                    "*X*",
-                    "***",
-                    '*',
-                    new ItemStack(Blocks.sand, 1),
-                    'X',
-                    new ItemStack(Blocks.tallgrass, 1, 2));
+            if (!Loader.isModLoaded("dreamcraft")) {
+                GameRegistry.addRecipe(
+                        new ItemStack(ChiselBlocks.hempcretesand, 8, 0),
+                        "***",
+                        "*X*",
+                        "***",
+                        '*',
+                        new ItemStack(Blocks.sand, 1),
+                        'X',
+                        new ItemStack(Blocks.tallgrass, 1, 2));
+            }
         }
     },
 

--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -1654,7 +1654,7 @@ public enum Features {
                     '*',
                     new ItemStack(Blocks.sand, 1),
                     'X',
-                    new ItemStack(Items.wheat, 1, 2));
+                    new ItemStack(Blocks.tallgrass, 1, 2));
         }
     },
 


### PR DESCRIPTION
On the chisel end just revert the broken change and turn the recipe off if coremod is loaded. A new recipe will be in coremod.