### PR TITLE
Clear render block instances on world unload to not leak the world

### DIFF
--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -84,4 +84,9 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
         renderBlocksFullbright.submapSmall = submapSmall;
         return renderBlocksFullbright;
     }
+
+    public static void clearRenderBlocksInstance() {
+        renderBlocksFullbright = null;
+    }
+
 }

--- a/src/main/java/team/chisel/item/chisel/ChiselController.java
+++ b/src/main/java/team/chisel/item/chisel/ChiselController.java
@@ -11,6 +11,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.cricketcraft.chisel.api.IChiselItem;
@@ -25,6 +26,7 @@ import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import team.chisel.Chisel;
 import team.chisel.carving.Carving;
+import team.chisel.client.render.SubmapManagerSpecialMaterial;
 import team.chisel.utils.General;
 
 public final class ChiselController {
@@ -160,4 +162,12 @@ public final class ChiselController {
             }
         }
     }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (event.world.isRemote) {
+            SubmapManagerSpecialMaterial.clearRenderBlocksInstance();
+        }
+    }
+
 }


### PR DESCRIPTION
Clears an instance of `RenderBlocksCTMFullbright` stored [here](https://github.com/Minecraft-TA/Chisel/blob/1a39f6a13d78b13c4b956181d93018c629d75245/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java#L51C20-L51C45) when leaving a world to prevent keeping the world object alive. The world object is stored in RenderBlocks which is extended by the class.

![image](https://github.com/GTNewHorizons/Chisel/assets/45769595/8bac47df-5195-4812-837c-76944a3867d8)
