### PR TITLE
Fix more memory leaks

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
+++ b/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
@@ -345,7 +345,12 @@ public enum TextureType {
 		}
 	}
 
-	public ISubmapManager createManagerFor(ICarvingVariation variation, String texturePath) {
+    public static void clearStatics() {
+        theRenderBlocksCTM = null;
+        theRenderBlocksColumn = null;
+    }
+
+    public ISubmapManager createManagerFor(ICarvingVariation variation, String texturePath) {
 		return new SubmapManagerDefault(this, variation, texturePath);
 	}
 

--- a/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
@@ -75,7 +75,7 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static RenderBlocksCTMFullbright rb;
+    private RenderBlocksCTMFullbright rb;
 
     private String color;
     private TextureSubmap submap, submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
@@ -14,7 +14,7 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerCarpetFloor extends SubmapManagerBase {
 
     @SideOnly(Side.CLIENT)
-    private static RenderBlocksCTM rb;
+    private RenderBlocksCTM rb;
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -16,7 +16,7 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerSlab implements ISubmapManager {
 
     @SideOnly(Side.CLIENT)
-    private static RenderBlocksCTM rb;
+    private RenderBlocksCTM rb;
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -48,7 +48,7 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
         }
     };
 
-    private static RenderBlocksCTMFullbright renderBlocksFullbright;
+    private RenderBlocksCTMFullbright renderBlocksFullbright;
 
     private String color;
     private MaterialType materialType;
@@ -83,10 +83,6 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
         renderBlocksFullbright.submap = submap;
         renderBlocksFullbright.submapSmall = submapSmall;
         return renderBlocksFullbright;
-    }
-
-    public static void clearRenderBlocksInstance() {
-        renderBlocksFullbright = null;
     }
 
 }

--- a/src/main/java/team/chisel/item/chisel/ChiselController.java
+++ b/src/main/java/team/chisel/item/chisel/ChiselController.java
@@ -18,6 +18,7 @@ import com.cricketcraft.chisel.api.IChiselItem;
 import com.cricketcraft.chisel.api.carving.ICarvingGroup;
 import com.cricketcraft.chisel.api.carving.ICarvingVariation;
 import com.cricketcraft.chisel.api.carving.IChiselMode;
+import com.cricketcraft.chisel.api.rendering.TextureType;
 import com.google.common.collect.Queues;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -26,7 +27,6 @@ import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import team.chisel.Chisel;
 import team.chisel.carving.Carving;
-import team.chisel.client.render.SubmapManagerSpecialMaterial;
 import team.chisel.utils.General;
 
 public final class ChiselController {
@@ -160,6 +160,13 @@ public final class ChiselController {
             if (open != null) {
                 open.run();
             }
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (event.world.isRemote) {
+            TextureType.clearStatics();
         }
     }
 

--- a/src/main/java/team/chisel/item/chisel/ChiselController.java
+++ b/src/main/java/team/chisel/item/chisel/ChiselController.java
@@ -163,11 +163,4 @@ public final class ChiselController {
         }
     }
 
-    @SubscribeEvent
-    public void onWorldUnload(WorldEvent.Unload event) {
-        if (event.world.isRemote) {
-            SubmapManagerSpecialMaterial.clearRenderBlocksInstance();
-        }
-    }
-
 }


### PR DESCRIPTION
Follow up to https://github.com/GTNewHorizons/Chisel/pull/35. Fixes more memory leaks that can just be fixed by converting static variables to normal fields which is also done in other render classes. The `TextureType` enum still requires a manual clear due to access issues. 