### PR TITLE
Don't relocate CTMLib

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,3 +62,6 @@ usesShadowedDependencies = true
 # Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
 # projects. New projects should not use this parameter.
 #customArchiveBaseName =
+
+# Use the team.chisel.ctmlib package name for CTMLib like upstream Chisel (needed by Techguns)
+relocateShadowedDependencies = false


### PR DESCRIPTION
Techguns uses the shaded CTMLib at the `team.chisel.ctmlib` package name. This was the package name used by upstream, and also in this fork prior to 2.10.17. In 2.10.17 this was changed to `com.cricketcraft.chisel.shadow.team.chisel.ctmlib` during the RFG migration, most likely by mistake. This PR restores the old package name, fixing this crash:

```
java.lang.NoClassDefFoundError: team.chisel.ctmlib.ISubmapManager
  at techguns.TGBlocks.init(TGBlocks.java:290) ~[TGBlocks.class:?]
```