### PR TITLE
Make Forge Multipart dependency optional

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/api/carving/CarvableHelper.java
+++ b/src/main/java/com/cricketcraft/chisel/api/carving/CarvableHelper.java
@@ -19,13 +19,13 @@ import com.cricketcraft.chisel.api.ChiselAPIProps;
 import com.cricketcraft.chisel.api.FMPIMC;
 import com.cricketcraft.chisel.api.rendering.TextureType;
 
-import codechicken.microblock.MicroMaterialRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.block.BlockCarvableGlowie;
-import team.chisel.client.render.FullBrightMicroMaterial;
+import team.chisel.compat.fmp.FMPCompat;
 import team.chisel.ctmlib.ISubmapManager;
 
 public class CarvableHelper {
@@ -190,14 +190,8 @@ public class CarvableHelper {
         Block block = info.getVariation()
             .getBlock();
 
-        if (block instanceof BlockCarvableGlowie) {
-            int meta = info.getVariation()
-                .getBlockMeta();
-
-            MicroMaterialRegistry.registerMaterial(
-                new FullBrightMicroMaterial(block, meta),
-                block.getUnlocalizedName() + ((meta > 0) ? ("_" + meta) : ""));
-
+        if (Loader.isModLoaded("ForgeMultipart") && block instanceof BlockCarvableGlowie) {
+            FMPCompat.registerGlowieVariation(info, block);
         } else {
             if (block.renderAsNormalBlock() || block.isOpaqueCube() || block.isNormalCube()) {
                 FMPIMC.registerFMP(

--- a/src/main/java/team/chisel/compat/fmp/FMPCompat.java
+++ b/src/main/java/team/chisel/compat/fmp/FMPCompat.java
@@ -3,13 +3,16 @@ package team.chisel.compat.fmp;
 import net.minecraft.block.Block;
 import net.minecraft.world.World;
 
+import com.cricketcraft.chisel.api.carving.IVariationInfo;
 import com.google.common.collect.Lists;
 
 import codechicken.lib.vec.BlockCoord;
+import codechicken.microblock.MicroMaterialRegistry;
 import codechicken.multipart.MultiPartRegistry;
 import codechicken.multipart.MultiPartRegistry.IPartConverter;
 import codechicken.multipart.MultiPartRegistry.IPartFactory;
 import codechicken.multipart.TMultiPart;
+import team.chisel.client.render.FullBrightMicroMaterial;
 import team.chisel.init.ChiselBlocks;
 
 public class FMPCompat implements IPartFactory, IPartConverter {
@@ -41,5 +44,14 @@ public class FMPCompat implements IPartFactory, IPartConverter {
             return new PartChiselTorch();
         }
         return null;
+    }
+
+    public static void registerGlowieVariation(IVariationInfo info, Block block) {
+        int meta = info.getVariation()
+            .getBlockMeta();
+
+        MicroMaterialRegistry.registerMaterial(
+            new FullBrightMicroMaterial(block, meta),
+            block.getUnlocalizedName() + ((meta > 0) ? ("_" + meta) : ""));
     }
 }


### PR DESCRIPTION
Fixes regression in 2150548. The code that references FMP is moved to `FMPCompat` since otherwise a `NoClassDefFoundError` would happen while loading `CarvableHelper` if FMP is not present.