### PR TITLE
fix mining levels with iguana

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation("com.github.GTNewHorizons:CodeChickenCore:1.1.11:dev")
     implementation("com.github.GTNewHorizons:CodeChickenLib:1.1.8:dev")
     implementation("com.github.GTNewHorizons:NotEnoughItems:2.4.13-GTNH:dev")
-	implementation("com.github.GTNewHorizons:ForgeMultipart:1.4.3:dev")
+	implementation("com.github.GTNewHorizons:ForgeMultipart:1.4.4:dev")
 
     compileOnly("org.projectlombok:lombok:1.18.24")
     annotationProcessor("org.projectlombok:lombok:1.18.24")

--- a/src/main/java/team/chisel/Chisel.java
+++ b/src/main/java/team/chisel/Chisel.java
@@ -75,6 +75,7 @@ public class Chisel {
     public static final BlockCarvable.SoundType soundMetalFootstep = new BlockCarvable.SoundType("metal", 1.0f, 1.0f);
     public static boolean multipartLoaded = false;
     public static boolean gtnhLoaded = false;
+    public static boolean iguanaTweaksLoaded = false;
     public static int renderEldritchId;
     public static int renderAutoChiselId;
     public static int renderGlowId;
@@ -147,6 +148,9 @@ public class Chisel {
 
         if (Loader.isModLoaded("dreamcraft")) {
             gtnhLoaded = true;
+        }
+        if (Loader.isModLoaded("IguanaTweaksTConstruct")) {
+            iguanaTweaksLoaded = true;
         }
         TabsInit.preInit();
         Features.preInit();

--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -940,7 +940,11 @@ public enum Features {
                 .setResistance(10F)
                 .setStepSound(Block.soundTypeMetal);
 
-            diamond_block.setHarvestLevel("pickaxe", 2);
+            if (Chisel.iguanaTweaksLoaded) {
+                diamond_block.setHarvestLevel("pickaxe", 4);
+            } else {
+                diamond_block.setHarvestLevel("pickaxe", 2);
+            }
 
             Carving.chisel.addVariation("diamond_block", Blocks.diamond_block, 0, 0);
             diamond_block.carverHelper.addVariation("tile.diamond.1.desc", 1, "diamond/terrain-diamond-embossed");
@@ -1035,7 +1039,11 @@ public enum Features {
                 .setResistance(10.0F)
                 .setStepSound(Block.soundTypeMetal);
 
-            emerald_block.setHarvestLevel("pickaxe", 2);
+            if (Chisel.iguanaTweaksLoaded) {
+                emerald_block.setHarvestLevel("pickaxe", 4);
+            } else {
+                emerald_block.setHarvestLevel("pickaxe", 2);
+            }
 
             Carving.chisel.addVariation("emerald_block", Blocks.emerald_block, 0, 0);
             emerald_block.carverHelper.addVariation("tile.emerald.1.desc", 1, "emerald/panel");
@@ -1519,7 +1527,11 @@ public enum Features {
                 .setResistance(10F)
                 .setStepSound(Block.soundTypeMetal);
 
-            gold_block.setHarvestLevel("pickaxe", 2);
+            if (Chisel.iguanaTweaksLoaded) {
+                gold_block.setHarvestLevel("pickaxe", 3);
+            } else {
+                gold_block.setHarvestLevel("pickaxe", 2);
+            }
 
             Carving.chisel.addVariation("gold_block", Blocks.gold_block, 0, 0);
             gold_block.carverHelper.addVariation("tile.gold.1.desc", 1, "gold/terrain-gold-largeingot");
@@ -1930,7 +1942,11 @@ public enum Features {
                 .setResistance(10F)
                 .setStepSound(Block.soundTypeMetal);
 
-            iron_block.setHarvestLevel("pickaxe", 1);
+            if (Chisel.iguanaTweaksLoaded) {
+                iron_block.setHarvestLevel("pickaxe", 2);
+            } else {
+                iron_block.setHarvestLevel("pickaxe", 1);
+            }
 
             Carving.chisel.addVariation("iron_block", Blocks.iron_block, 0, 0);
             iron_block.carverHelper.addVariation("tile.iron.1.desc", 1, "iron/terrain-iron-largeingot");
@@ -2044,7 +2060,11 @@ public enum Features {
                 .setResistance(5F)
                 .setStepSound(Block.soundTypeStone);
 
-            lapis_block.setHarvestLevel("pickaxe", 1);
+            if (Chisel.iguanaTweaksLoaded) {
+                lapis_block.setHarvestLevel("pickaxe", 2);
+            } else {
+                lapis_block.setHarvestLevel("pickaxe", 1);
+            }
 
             Carving.chisel.addVariation("lapis_block", Blocks.lapis_block, 0, 0);
             lapis_block.carverHelper.addVariation("tile.lapis.1.desc", 1, "lapis/terrain-lapisblock-chunky");
@@ -2804,7 +2824,11 @@ public enum Features {
                 .setResistance(2000.0F)
                 .setStepSound(Block.soundTypeStone);
 
-            obsidian.setHarvestLevel("pickaxe", 3);
+            if (Chisel.iguanaTweaksLoaded) {
+                obsidian.setHarvestLevel("pickaxe", 5);
+            } else {
+                obsidian.setHarvestLevel("pickaxe", 3);
+            }
 
             Carving.chisel.addVariation("obsidian", Blocks.obsidian, 0, 0);
             obsidian.carverHelper.addVariation("tile.obsidian.1.desc", 1, "obsidian/pillar");


### PR DESCRIPTION
GTNH fix to the added mining levels. I found that the change for vanilla is done in iguanatweaks (https://github.com/GTNewHorizons/IguanaTweaksTConstruct/blob/9ef99b513d4239ee666c28984ef641c216b9075c/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/HarvestLevelTweaks.java#L39C30-L39C30, now that I know what to search for), so I made that the condition for theoretically full compat outside of GTNH.

in GTNH:
![image](https://github.com/GTNewHorizons/Chisel/assets/40274384/825c0f28-8e9c-40af-a2de-4efed8526510)
![image](https://github.com/GTNewHorizons/Chisel/assets/40274384/e252e36f-594b-42a5-bf28-ccf3ccbc1055)

part of https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/111

