### PR TITLE
Another Obsidian harvestlevel fix

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -3520,6 +3520,11 @@ public enum Features {
                     .setHardness(50.0F)
                     .setResistance(2000.0F);
             GameRegistry.registerBlock(obsidian_snakestone, ItemCarvable.class, "obsidian_snakestone");
+            if (Chisel.iguanaTweaksLoaded) {
+                obsidian_snakestone.setHarvestLevel("pickaxe", 5);
+            } else {
+                obsidian_snakestone.setHarvestLevel("pickaxe", 3);
+            }
             Carving.chisel.addVariation("obsidian", obsidian_snakestone, 1, 100);
             Carving.chisel.addVariation("obsidian", obsidian_snakestone, 13, 101);
             // Carving.chisel.registerOre("obsidianSnakestone",


### PR DESCRIPTION
Fix mining level for obsidian snakestone. that was missed in the two previous PRs.

this is more work on https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/111

![image](https://github.com/GTNewHorizons/Chisel/assets/40274384/79e580e9-9469-4e75-9289-0cc187ed82e0)
