### PR TITLE
Fix Glotek and Neonite being only obtainable with `allowChiselCrossColors`

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -1455,10 +1455,6 @@ public enum Features {
             BlockCarvable glotek = (BlockCarvable) new BlockCarvableGlowie(Material.rock)
                 .setCreativeTab(ChiselTabs.tabOtherChiselBlocks);
 
-            if (!Configurations.allowChiselCrossColors) {
-                glotek.carverHelper.forbidChiseling = true;
-            }
-
             for (int i = 0; i < 16; i++) {
                 glotek.carverHelper.addVariation(
                     "tile.glotek." + i + ".desc",
@@ -2657,10 +2653,6 @@ public enum Features {
         void addBlocks() {
             BlockCarvable neonite = (BlockCarvable) new BlockCarvableGlowie(Material.rock)
                 .setCreativeTab(ChiselTabs.tabOtherChiselBlocks);
-
-            if (!Configurations.allowChiselCrossColors) {
-                neonite.carverHelper.forbidChiseling = true;
-            }
 
             for (int i = 0; i < 16; i++) {
                 neonite.carverHelper.addVariation(


### PR DESCRIPTION
Remove Glotek and Neonite from being affected by:
```
# Should someone be able to chisel something into a different color.
    B:allowChiselCrossColors=false
```
They do not have recipes for each color variation, making them unobtainable should `allowChiselCrossColors` be false which is not intended.