### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/chisel/lang/en_US.lang
+++ b/src/main/resources/assets/chisel/lang/en_US.lang
@@ -27,6 +27,7 @@ item.cloudBottle.name=Cloud In A Bottle
 item.cloudBottle.desc=Right-Click to throw. This will spawn clouds on impact.
 item.smashingRock.name=Smashing Rock
 item.smashingRock.desc=Right-Click to throw. This will turn Cobblestone into Gravel, Gravel into Sand etc on impact.
+item.upgrade.name=Upgrade
 item.upgrade_speed.name=Speed Upgrade
 item.upgrade_automation.name=Automation Upgrade
 item.upgrade_stack.name=Stack Upgrade
@@ -1894,3 +1895,6 @@ tile.froglight.6.desc=Girisium
 tile.froglight.7.desc=Orundum
 tile.froglight.8.desc=Blood-Stained
 tile.froglight.9.desc=Ichor
+
+tile.chisel.amber.name=Block of Amber
+tile.chisel.bloodBrick.name=Bloodstone Brick


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.