### PR TITLE
fix endstone oredict

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -1086,7 +1086,9 @@ public enum Features {
             end_Stone.carverHelper.addVariation("tile.end_Stone.13.desc", 13, "endstone/endStoneLargeTile");
             end_Stone.carverHelper.registerBlock(end_Stone, "end_Stone");
             end_Stone.carverHelper.registerVariations("end_stone");
-            end_Stone.carverHelper.registerOre("blockEndstone");
+            if (!Loader.isModLoaded("dreamcraft")) {
+                end_Stone.carverHelper.registerOre("blockEndstone");
+            }
             Carving.chisel.registerOre("end_stone", "blockEndstone");
         }
     },


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10099

to elaborate: in GTNH end stone is oredicted as stone, not block.

depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/3793