### PR TITLE
Move Snakestone head and body blocks into the Smooth Stone chisel group

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -3501,8 +3501,12 @@ public enum Features {
             // "Stone snake block head");
             // LanguageRegistry.addName(new ItemStack(snakestone, 1, 13),
             // "Stone snake block body");
-            Carving.chisel.addVariation("stonebrick", stone_snakestone, 1, 100);
-            Carving.chisel.addVariation("stonebrick", stone_snakestone, 13, 101);
+
+            // https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12982
+            // Fix: Snakestone blocks moved into the "Smooth Stone" chisel group
+            Carving.chisel.addVariation("stonebricksmooth", stone_snakestone, 1, 20);
+            Carving.chisel.addVariation("stonebricksmooth", stone_snakestone, 13, 21);
+
             // Carving.chisel.registerOre("snakestoneStone", "snakestoneStone");
         }
     },


### PR DESCRIPTION
I was going through old stale issues, this one seemed like a pretty simple fix.
Moved the Chisel Snakestone blocks (Head and Body) into the Smooth Stone group, thus making them acquirable in survival.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12982

Tested with Daily 75