### PR TITLE
Make rendering blocks thread safe with Angelica

### DIFF
--- a/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
@@ -75,7 +75,8 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private RenderBlocksCTMFullbright rb;
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTMFullbright::new);
 
     private String color;
     private TextureSubmap submap, submapSmall;
@@ -99,9 +100,7 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        if (rb == null) {
-            rb = new RenderBlocksCTMFullbright();
-        }
+        RenderBlocksCTMFullbright rb = renderBlocksThreadLocal.get();
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
@@ -75,8 +75,7 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTMFullbright::new);
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = new ThreadLocal<>();
 
     private String color;
     private TextureSubmap submap, submapSmall;
@@ -101,6 +100,10 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
         RenderBlocksCTMFullbright rb = renderBlocksThreadLocal.get();
+        if (rb == null) {
+            rb = new RenderBlocksCTMFullbright();
+            renderBlocksThreadLocal.set(rb);
+        }
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
@@ -75,7 +75,13 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = new ThreadLocal<>();
+    private static ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal;
+
+    private static void initStatics() {
+        if (renderBlocksThreadLocal == null) {
+            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTMFullbright::new);
+        }
+    }
 
     private String color;
     private TextureSubmap submap, submapSmall;
@@ -99,11 +105,8 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        initStatics();
         RenderBlocksCTMFullbright rb = renderBlocksThreadLocal.get();
-        if (rb == null) {
-            rb = new RenderBlocksCTMFullbright();
-            renderBlocksThreadLocal.set(rb);
-        }
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
@@ -14,7 +14,8 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerCarpetFloor extends SubmapManagerBase {
 
     @SideOnly(Side.CLIENT)
-    private RenderBlocksCTM rb;
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTM::new);
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
@@ -45,9 +46,7 @@ public class SubmapManagerCarpetFloor extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        if (rb == null) {
-            rb = new RenderBlocksCTM();
-        }
+        RenderBlocksCTM rb = renderBlocksThreadLocal.get();
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
@@ -14,7 +14,13 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerCarpetFloor extends SubmapManagerBase {
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = new ThreadLocal<>();
+    private static ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal;
+
+    private static void initStatics() {
+        if (renderBlocksThreadLocal == null) {
+            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTM::new);
+        }
+    }
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
@@ -45,11 +51,8 @@ public class SubmapManagerCarpetFloor extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        initStatics();
         RenderBlocksCTM rb = renderBlocksThreadLocal.get();
-        if (rb == null) {
-            rb = new RenderBlocksCTM();
-            renderBlocksThreadLocal.set(rb);
-        }
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
@@ -14,8 +14,7 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerCarpetFloor extends SubmapManagerBase {
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTM::new);
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = new ThreadLocal<>();
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
@@ -47,6 +46,10 @@ public class SubmapManagerCarpetFloor extends SubmapManagerBase {
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
         RenderBlocksCTM rb = renderBlocksThreadLocal.get();
+        if (rb == null) {
+            rb = new RenderBlocksCTM();
+            renderBlocksThreadLocal.set(rb);
+        }
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
@@ -99,7 +99,7 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
     }
 
     @SideOnly(Side.CLIENT)
-    private RenderBlocksCTM rb;
+    private static final ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal = new ThreadLocal<>();
 
     private TextureSubmap submap, smallSubmap;
     private int size;
@@ -133,8 +133,10 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        RenderBlocksCombinedCTM rb = renderBlocksThreadLocal.get();
         if (rb == null) {
             rb = new RenderBlocksCombinedCTM();
+            renderBlocksThreadLocal.set(rb);
         }
         rb.setRenderBoundsFromBlock(block);
         return rb;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
@@ -99,7 +99,13 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
     }
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal = new ThreadLocal<>();
+    private static ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal;
+
+    private static void initStatics() {
+        if (renderBlocksThreadLocal == null) {
+            renderBlocksThreadLocal = new ThreadLocal<>();
+        }
+    }
 
     private TextureSubmap submap, smallSubmap;
     private int size;
@@ -133,6 +139,7 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        initStatics();
         RenderBlocksCombinedCTM rb = renderBlocksThreadLocal.get();
         if (rb == null) {
             rb = new RenderBlocksCombinedCTM();

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -16,7 +16,8 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerSlab implements ISubmapManager {
 
     @SideOnly(Side.CLIENT)
-    private RenderBlocksCTM rb;
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTM::new);
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
@@ -49,9 +50,7 @@ public class SubmapManagerSlab implements ISubmapManager {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        if (rb == null) {
-            rb = new RenderBlocksCTM();
-        }
+        RenderBlocksCTM rb = renderBlocksThreadLocal.get();
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -16,7 +16,13 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerSlab implements ISubmapManager {
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = new ThreadLocal<>();
+    private static ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal;
+
+    private static void initStatics() {
+        if (renderBlocksThreadLocal == null) {
+            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTM::new);
+        }
+    }
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
@@ -49,11 +55,8 @@ public class SubmapManagerSlab implements ISubmapManager {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        initStatics();
         RenderBlocksCTM rb = renderBlocksThreadLocal.get();
-        if (rb == null) {
-            rb = new RenderBlocksCTM();
-            renderBlocksThreadLocal.set(rb);
-        }
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -16,8 +16,7 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerSlab implements ISubmapManager {
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTM::new);
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = new ThreadLocal<>();
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
@@ -51,6 +50,10 @@ public class SubmapManagerSlab implements ISubmapManager {
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
         RenderBlocksCTM rb = renderBlocksThreadLocal.get();
+        if (rb == null) {
+            rb = new RenderBlocksCTM();
+            renderBlocksThreadLocal.set(rb);
+        }
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;
         rb.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -48,7 +48,9 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
         }
     };
 
-    private RenderBlocksCTMFullbright renderBlocksFullbright;
+    @SideOnly(Side.CLIENT)
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTMFullbright::new);
 
     private String color;
     private MaterialType materialType;
@@ -76,9 +78,7 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        if (renderBlocksFullbright == null) {
-            renderBlocksFullbright = new RenderBlocksCTMFullbright();
-        }
+        RenderBlocksCTMFullbright renderBlocksFullbright = renderBlocksThreadLocal.get();
         renderBlocksFullbright.setRenderBoundsFromBlock(block);
         renderBlocksFullbright.submap = submap;
         renderBlocksFullbright.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -49,8 +49,7 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTMFullbright::new);
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = new ThreadLocal<>();
 
     private String color;
     private MaterialType materialType;
@@ -79,6 +78,10 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
         RenderBlocksCTMFullbright renderBlocksFullbright = renderBlocksThreadLocal.get();
+        if (renderBlocksFullbright == null) {
+            renderBlocksFullbright = new RenderBlocksCTMFullbright();
+            renderBlocksThreadLocal.set(renderBlocksFullbright);
+        }
         renderBlocksFullbright.setRenderBoundsFromBlock(block);
         renderBlocksFullbright.submap = submap;
         renderBlocksFullbright.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -49,7 +49,13 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = new ThreadLocal<>();
+    private static ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal;
+
+    private static void initStatics() {
+        if (renderBlocksThreadLocal == null) {
+            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTMFullbright::new);
+        }
+    }
 
     private String color;
     private MaterialType materialType;
@@ -77,11 +83,8 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        initStatics();
         RenderBlocksCTMFullbright renderBlocksFullbright = renderBlocksThreadLocal.get();
-        if (renderBlocksFullbright == null) {
-            renderBlocksFullbright = new RenderBlocksCTMFullbright();
-            renderBlocksThreadLocal.set(renderBlocksFullbright);
-        }
         renderBlocksFullbright.setRenderBoundsFromBlock(block);
         renderBlocksFullbright.submap = submap;
         renderBlocksFullbright.submapSmall = submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
@@ -79,7 +79,13 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
     }
 
     @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal = new ThreadLocal<>();
+    private static ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal;
+
+    private static void initStatics() {
+        if (renderBlocksThreadLocal == null) {
+            renderBlocksThreadLocal = new ThreadLocal<>();
+        }
+    }
 
     private ISubmapManager overlay;
     private TextureSubmap base;
@@ -123,6 +129,7 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        initStatics();
         RenderBlocksVoidstone rb = renderBlocksThreadLocal.get();
         if (rb == null) {
             rb = new RenderBlocksVoidstone();

--- a/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
@@ -79,7 +79,7 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
     }
 
     @SideOnly(Side.CLIENT)
-    private RenderBlocksVoidstone rb;
+    private static final ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal = new ThreadLocal<>();
 
     private ISubmapManager overlay;
     private TextureSubmap base;
@@ -123,8 +123,10 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
+        RenderBlocksVoidstone rb = renderBlocksThreadLocal.get();
         if (rb == null) {
             rb = new RenderBlocksVoidstone();
+            renderBlocksThreadLocal.set(rb);
         }
         RenderBlocks ctx = overlay.createRenderContext(rendererOld, block, world);
         rb.setRenderBoundsFromBlock(block);


### PR DESCRIPTION
Since LittleTiles is multi threaded now, making little chisel tiles lead to race conditions.
This PR addresses this by making chisel blocks threadsafe as well. Some already were, this make it for all.