### PR TITLE
[Memory-opti:fix leak] Fix world client memory leaks caused by block renderers

### DIFF
--- a/src/main/java/com/cricketcraft/chisel/api/carving/VariationInfoBase.java
+++ b/src/main/java/com/cricketcraft/chisel/api/carving/VariationInfoBase.java
@@ -14,10 +14,10 @@ import team.chisel.ctmlib.ISubmapManager;
 
 public class VariationInfoBase implements IVariationInfo {
 
-    private ICarvingVariation variation;
-    private String unlocDesc;
-    private ISubmapManager manager;
-    private TextureType type;
+    private final ICarvingVariation variation;
+    private final String unlocDesc;
+    private final ISubmapManager manager;
+    private final TextureType type;
 
     public VariationInfoBase(ICarvingVariation variation, String unlocDesc, ISubmapManager manager) {
         this(variation, unlocDesc, manager, TextureType.CUSTOM);

--- a/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
+++ b/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
@@ -337,12 +337,12 @@ public enum TextureType {
 	@SideOnly(Side.CLIENT)
 	private static ThreadLocal<RenderBlocksColumn> theRenderBlocksColumn;
 
-	private String[] suffixes;
+	private final String[] suffixes;
 	static {
 		VALUES = ArrayUtils.subarray(values(), 0, values().length - 1);
 	}
 
-	private TextureType(String... suffixes) {
+	TextureType(String... suffixes) {
 		this.suffixes = suffixes.length == 0 ? new String[] { "" } : suffixes;
 	}
 

--- a/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
+++ b/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
@@ -91,9 +91,9 @@ public enum TextureType {
 			TextureSubmap map = data.getLeft();
 			if (topConnected && botConnected)
 				return map.getSubIcon(0, 1);
-			if (topConnected && !botConnected)
+			if (topConnected)
 				return map.getSubIcon(1, 1);
-			if (!topConnected && botConnected)
+			if (botConnected)
 				return map.getSubIcon(1, 0);
 			return map.getSubIcon(0, 0);
 		}
@@ -101,7 +101,6 @@ public enum TextureType {
 		@Override
 		@SideOnly(Side.CLIENT)
 		protected RenderBlocks createRenderContext(RenderBlocks rendererOld, IBlockAccess world, Object cachedObject) {
-            TextureType.initStatics();
 			RenderBlocksColumn ret = theRenderBlocksColumn.get();
 			Pair<TextureSubmap, IIcon> data = (Pair<TextureSubmap, IIcon>) cachedObject;
 
@@ -206,7 +205,6 @@ public enum TextureType {
 		@Override
 		@SideOnly(Side.CLIENT)
 		protected RenderBlocks createRenderContext(RenderBlocks rendererOld, IBlockAccess world, Object cachedObject) {
-            TextureType.initStatics();
 			RenderBlocksCTM ret = theRenderBlocksCTM.get();
 			Triple<?, TextureSubmap, TextureSubmap> data = (Triple<?, TextureSubmap, TextureSubmap>) cachedObject;
 
@@ -331,9 +329,9 @@ public enum TextureType {
 	private static final CTM ctm = CTM.getInstance();
 	private static final Random rand = new Random();
 	@SideOnly(Side.CLIENT)
-	private static ThreadLocal<RenderBlocksCTM> theRenderBlocksCTM;
+	private static final ThreadLocal<RenderBlocksCTM> theRenderBlocksCTM = ThreadLocal.withInitial(RenderBlocksCTM::new);
 	@SideOnly(Side.CLIENT)
-	private static ThreadLocal<RenderBlocksColumn> theRenderBlocksColumn;
+	private static final ThreadLocal<RenderBlocksColumn> theRenderBlocksColumn = ThreadLocal.withInitial(RenderBlocksColumn::new);
 
 	private final String[] suffixes;
 	static {
@@ -343,19 +341,6 @@ public enum TextureType {
 	TextureType(String... suffixes) {
 		this.suffixes = suffixes.length == 0 ? new String[] { "" } : suffixes;
 	}
-
-    private static void initStatics() {
-        if (theRenderBlocksCTM == null) {
-            theRenderBlocksCTM = ThreadLocal.withInitial(RenderBlocksCTM::new);
-            theRenderBlocksColumn = ThreadLocal.withInitial(RenderBlocksColumn::new);
-        }
-    }
-
-    @SideOnly(Side.CLIENT)
-    public static void clearStatics() {
-        if(theRenderBlocksCTM != null) theRenderBlocksCTM.remove();
-        if(theRenderBlocksColumn != null) theRenderBlocksColumn.remove();
-    }
 
     public ISubmapManager createManagerFor(ICarvingVariation variation, String texturePath) {
 		return new SubmapManagerDefault(this, variation, texturePath);

--- a/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
+++ b/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
@@ -105,7 +105,6 @@ public enum TextureType {
 			RenderBlocksColumn ret = theRenderBlocksColumn.get();
 			Pair<TextureSubmap, IIcon> data = (Pair<TextureSubmap, IIcon>) cachedObject;
 
-			ret.blockAccess = world;
 			ret.renderMaxX = 1.0;
 			ret.renderMaxY = 1.0;
 			ret.renderMaxZ = 1.0;
@@ -210,7 +209,6 @@ public enum TextureType {
             TextureType.initStatics();
 			RenderBlocksCTM ret = theRenderBlocksCTM.get();
 			Triple<?, TextureSubmap, TextureSubmap> data = (Triple<?, TextureSubmap, TextureSubmap>) cachedObject;
-			ret.blockAccess = world;
 
 			ret.submap = data.getMiddle();
 			ret.submapSmall = data.getRight();

--- a/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
+++ b/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import com.cricketcraft.chisel.api.carving.CarvableHelper;
 import com.cricketcraft.chisel.api.carving.ICarvingVariation;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.CTM;
@@ -327,10 +328,8 @@ public enum TextureType {
 	private static final TextureType[] VALUES;
 	private static final CTM ctm = CTM.getInstance();
 	private static final Random rand = new Random();
-	@SideOnly(Side.CLIENT)
-	private static final ThreadLocal<RenderBlocksCTM> theRenderBlocksCTM = ThreadLocal.withInitial(RenderBlocksCTM::new);
-	@SideOnly(Side.CLIENT)
-	private static final ThreadLocal<RenderBlocksColumn> theRenderBlocksColumn = ThreadLocal.withInitial(RenderBlocksColumn::new);
+	private static final ThreadLocal<RenderBlocksCTM> theRenderBlocksCTM = FMLLaunchHandler.side().isClient() ? ThreadLocal.withInitial(RenderBlocksCTM::new) : null;
+	private static final ThreadLocal<RenderBlocksColumn> theRenderBlocksColumn = FMLLaunchHandler.side().isClient() ? ThreadLocal.withInitial(RenderBlocksColumn::new) : null;
 
 	private final String[] suffixes;
 	static {

--- a/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
+++ b/src/main/java/com/cricketcraft/chisel/api/rendering/TextureType.java
@@ -211,7 +211,6 @@ public enum TextureType {
 			ret.submap = data.getMiddle();
 			ret.submapSmall = data.getRight();
 
-			ret.rendererOld = rendererOld;
 			return ret;
 		}
 	},

--- a/src/main/java/team/chisel/client/render/RendererCTMPane.java
+++ b/src/main/java/team/chisel/client/render/RendererCTMPane.java
@@ -19,11 +19,7 @@ import team.chisel.ctmlib.Drawing;
 @ThreadSafeISBRH(perThread = false)
 public class RendererCTMPane implements ISimpleBlockRenderingHandler {
 
-    public static int id;
-
-    public RendererCTMPane() {
-        id = RenderingRegistry.getNextAvailableRenderId();
-    }
+    public static final int id = RenderingRegistry.getNextAvailableRenderId();
 
     @Override
     public void renderInventoryBlock(Block block, int meta, int modelID, RenderBlocks renderer) {
@@ -33,7 +29,7 @@ public class RendererCTMPane implements ISimpleBlockRenderingHandler {
         Drawing.drawBlock(block, meta, renderer);
     }
 
-    class PaneRenderer {
+    static class PaneRenderer {
 
         double i0u0;
         double i0uh;

--- a/src/main/java/team/chisel/client/render/RendererEldritch.java
+++ b/src/main/java/team/chisel/client/render/RendererEldritch.java
@@ -27,7 +27,8 @@ public class RendererEldritch implements ISimpleBlockRenderingHandler {
         GL11.glTranslatef(0.5F, 0.5F, 0.5F);
     }
 
-    ThreadLocal<RenderBlocksEldritch> rendererThreadLocal = ThreadLocal.withInitial(RenderBlocksEldritch::new);
+    private static final ThreadLocal<RenderBlocksEldritch> rendererThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksEldritch::new);
 
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
@@ -59,7 +60,11 @@ public class RendererEldritch implements ISimpleBlockRenderingHandler {
         renderer.renderMaxX = 1.0;
         renderer.renderMaxY = 1.0;
         renderer.renderMaxZ = 1.0;
-        renderer.renderStandardBlock(block, x, y, z);
+        try {
+            renderer.renderStandardBlock(block, x, y, z);
+        } finally {
+            renderer.blockAccess = null;
+        }
 
         return true;
         /*

--- a/src/main/java/team/chisel/client/render/RendererMultiLayer.java
+++ b/src/main/java/team/chisel/client/render/RendererMultiLayer.java
@@ -28,17 +28,11 @@ public class RendererMultiLayer implements ISimpleBlockRenderingHandler {
 
     final static float bot = -0.001f;
     final static float top = 1.0f - bot;
-    public static int id;
-
-    public RendererMultiLayer() {
-        id = RenderingRegistry.getNextAvailableRenderId();
-    }
+    public static final int id = RenderingRegistry.getNextAvailableRenderId();
 
     @Override
     public void renderInventoryBlock(Block blck, int meta, int modelID, RenderBlocks renderer) {
-        if (blck == null || !(blck instanceof BlockMultiLayerBase)) return;
-
-        BlockMultiLayerBase block = (BlockMultiLayerBase) blck;
+        if (!(blck instanceof BlockMultiLayerBase block)) return;
 
         if (block.icon != null) {
             renderer.overrideBlockTexture = block.icon;
@@ -61,8 +55,7 @@ public class RendererMultiLayer implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block blck, int modelId,
         RenderBlocks renderer) {
-        if (blck == null || !(blck instanceof BlockMultiLayerBase)) return false;
-        BlockMultiLayerBase block = (BlockMultiLayerBase) blck;
+        if (!(blck instanceof BlockMultiLayerBase block)) return false;
 
         if (MinecraftForgeClient.getRenderPass() == 0) {
             if (block.icon != null) {

--- a/src/main/java/team/chisel/client/render/RendererStairs.java
+++ b/src/main/java/team/chisel/client/render/RendererStairs.java
@@ -16,11 +16,7 @@ import team.chisel.ctmlib.Drawing;
 @ThreadSafeISBRH(perThread = false)
 public class RendererStairs implements ISimpleBlockRenderingHandler {
 
-    public static int id;
-
-    public RendererStairs() {
-        id = RenderingRegistry.getNextAvailableRenderId();
-    }
+    public static final int id = RenderingRegistry.getNextAvailableRenderId();
 
     @Override
     public void renderInventoryBlock(Block block, int meta, int modelID, RenderBlocks renderer) {
@@ -34,8 +30,7 @@ public class RendererStairs implements ISimpleBlockRenderingHandler {
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block blck, int modelId,
         RenderBlocks renderer) {
-        if (blck == null || !(blck instanceof BlockCarvableStairs)) return false;
-        BlockCarvableStairs block = (BlockCarvableStairs) blck;
+        if (!(blck instanceof BlockCarvableStairs block)) return false;
 
         renderer.renderBlockStairs(block, x, y, z);
 

--- a/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
@@ -75,15 +75,10 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal;
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTMFullbright::new);
 
-    private static void initStatics() {
-        if (renderBlocksThreadLocal == null) {
-            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTMFullbright::new);
-        }
-    }
-
-    private String color;
+    private final String color;
     private TextureSubmap submap, submapSmall;
 
     public SubmapManagerAntiblock(String color) {
@@ -105,7 +100,6 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        initStatics();
         RenderBlocksCTMFullbright rb = renderBlocksThreadLocal.get();
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;

--- a/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerAntiblock.java
@@ -10,6 +10,7 @@ import net.minecraftforge.client.IItemRenderer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.Drawing;
@@ -74,9 +75,8 @@ public class SubmapManagerAntiblock extends SubmapManagerBase {
         }
     };
 
-    @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTMFullbright::new);
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = FMLLaunchHandler.side()
+        .isClient() ? ThreadLocal.withInitial(RenderBlocksCTMFullbright::new) : null;
 
     private final String color;
     private TextureSubmap submap, submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
@@ -6,6 +6,7 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.RenderBlocksCTM;
@@ -13,9 +14,8 @@ import team.chisel.ctmlib.TextureSubmap;
 
 public class SubmapManagerCarpetFloor extends SubmapManagerBase {
 
-    @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTM::new);
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = FMLLaunchHandler.side()
+        .isClient() ? ThreadLocal.withInitial(RenderBlocksCTM::new) : null;
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCarpetFloor.java
@@ -14,17 +14,12 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerCarpetFloor extends SubmapManagerBase {
 
     @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal;
-
-    private static void initStatics() {
-        if (renderBlocksThreadLocal == null) {
-            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTM::new);
-        }
-    }
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTM::new);
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
-    private String color;
+    private final String color;
 
     public SubmapManagerCarpetFloor(String color) {
         this.color = color;
@@ -51,7 +46,6 @@ public class SubmapManagerCarpetFloor extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        initStatics();
         RenderBlocksCTM rb = renderBlocksThreadLocal.get();
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
@@ -14,6 +14,7 @@ import com.cricketcraft.chisel.api.carving.CarvingUtils;
 import com.cricketcraft.chisel.api.rendering.TextureType;
 import com.cricketcraft.chisel.api.rendering.TextureType.AbstractSubmapManager;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.RenderBlocksCTM;
@@ -98,9 +99,8 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
         }
     }
 
-    @SideOnly(Side.CLIENT)
-    private final ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCombinedCTM::new);
+    private final ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal = FMLLaunchHandler.side()
+        .isClient() ? ThreadLocal.withInitial(RenderBlocksCombinedCTM::new) : null;
 
     private TextureSubmap submap, smallSubmap;
     private final int size;

--- a/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerCombinedCTM.java
@@ -78,9 +78,9 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
         }
     }
 
-    private class Submap extends TextureSubmap {
+    private static class Submap extends TextureSubmap {
 
-        private TextureSubmap[][] submap;
+        private final TextureSubmap[][] submap;
 
         public Submap(IIcon base, int wh, TextureSubmap[][] submap) {
             super(base, wh, wh);
@@ -99,20 +99,15 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
     }
 
     @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal;
-
-    private static void initStatics() {
-        if (renderBlocksThreadLocal == null) {
-            renderBlocksThreadLocal = new ThreadLocal<>();
-        }
-    }
+    private final ThreadLocal<RenderBlocksCombinedCTM> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCombinedCTM::new);
 
     private TextureSubmap submap, smallSubmap;
-    private int size;
-    private String texturePath;
-    private int meta;
+    private final int size;
+    private final String texturePath;
+    private final int meta;
     private IIcon defaultIcon;
-    private TextureType rType;
+    private final TextureType rType;
 
     public SubmapManagerCombinedCTM(int meta, String texturePath, TextureType rType) {
         assert rType == TextureType.R16 || rType == TextureType.R9
@@ -124,10 +119,7 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
         this.texturePath = texturePath;
         this.size = Integer.parseInt(
             rType.name()
-                .substring(
-                    1,
-                    rType.name()
-                        .length())); // >.>
+                .substring(1)); // >.>
         this.rType = rType;
     }
 
@@ -139,12 +131,7 @@ public class SubmapManagerCombinedCTM extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        initStatics();
         RenderBlocksCombinedCTM rb = renderBlocksThreadLocal.get();
-        if (rb == null) {
-            rb = new RenderBlocksCombinedCTM();
-            renderBlocksThreadLocal.set(rb);
-        }
         rb.setRenderBoundsFromBlock(block);
         return rb;
     }

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -16,18 +16,13 @@ import team.chisel.ctmlib.TextureSubmap;
 public class SubmapManagerSlab implements ISubmapManager {
 
     @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal;
-
-    private static void initStatics() {
-        if (renderBlocksThreadLocal == null) {
-            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTM::new);
-        }
-    }
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTM::new);
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;
     private IIcon sideTexture;
-    private String texture;
+    private final String texture;
 
     public SubmapManagerSlab(String texture) {
         this.texture = texture;
@@ -55,7 +50,6 @@ public class SubmapManagerSlab implements ISubmapManager {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        initStatics();
         RenderBlocksCTM rb = renderBlocksThreadLocal.get();
         rb.setRenderBoundsFromBlock(block);
         rb.submap = submap;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -7,6 +7,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.ISubmapManager;
@@ -15,9 +16,8 @@ import team.chisel.ctmlib.TextureSubmap;
 
 public class SubmapManagerSlab implements ISubmapManager {
 
-    @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTM::new);
+    private static final ThreadLocal<RenderBlocksCTM> renderBlocksThreadLocal = FMLLaunchHandler.side()
+        .isClient() ? ThreadLocal.withInitial(RenderBlocksCTM::new) : null;
 
     private TextureSubmap submap;
     private TextureSubmap submapSmall;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSlab.java
@@ -57,25 +57,11 @@ public class SubmapManagerSlab implements ISubmapManager {
         return rb;
     }
 
-    private boolean hadOverride = false;
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void preRenderSide(RenderBlocks renderer, IBlockAccess world, int x, int y, int z, ForgeDirection side) {}
 
     @Override
     @SideOnly(Side.CLIENT)
-    public void preRenderSide(RenderBlocks renderer, IBlockAccess world, int x, int y, int z, ForgeDirection side) {
-        RenderBlocksCTM rbctm = (RenderBlocksCTM) renderer;
-        if (side.ordinal() < 2 && !rbctm.rendererOld.hasOverrideBlockTexture()) {
-            rbctm.rendererOld.setOverrideBlockTexture(sideTexture);
-            hadOverride = false;
-        } else {
-            hadOverride = true;
-        }
-    }
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public void postRenderSide(RenderBlocks renderer, IBlockAccess world, int x, int y, int z, ForgeDirection side) {
-        if (!hadOverride) {
-            ((RenderBlocksCTM) renderer).rendererOld.clearOverrideBlockTexture();
-        }
-    }
+    public void postRenderSide(RenderBlocks renderer, IBlockAccess world, int x, int y, int z, ForgeDirection side) {}
 }

--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -6,6 +6,7 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.RenderBlocksCTM;
@@ -48,9 +49,8 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
         }
     };
 
-    @SideOnly(Side.CLIENT)
-    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksCTMFullbright::new);
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = FMLLaunchHandler.side()
+        .isClient() ? ThreadLocal.withInitial(RenderBlocksCTMFullbright::new) : null;
 
     private final String color;
     private final MaterialType materialType;

--- a/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerSpecialMaterial.java
@@ -49,16 +49,11 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     };
 
     @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal;
+    private static final ThreadLocal<RenderBlocksCTMFullbright> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksCTMFullbright::new);
 
-    private static void initStatics() {
-        if (renderBlocksThreadLocal == null) {
-            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksCTMFullbright::new);
-        }
-    }
-
-    private String color;
-    private MaterialType materialType;
+    private final String color;
+    private final MaterialType materialType;
     private TextureSubmap submap, submapSmall;
 
     public SubmapManagerSpecialMaterial(String color, MaterialType materialType) {
@@ -83,7 +78,6 @@ public class SubmapManagerSpecialMaterial extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        initStatics();
         RenderBlocksCTMFullbright renderBlocksFullbright = renderBlocksThreadLocal.get();
         renderBlocksFullbright.setRenderBoundsFromBlock(block);
         renderBlocksFullbright.submap = submap;

--- a/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
@@ -11,6 +11,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import com.cricketcraft.chisel.api.carving.CarvingUtils;
 import com.cricketcraft.chisel.api.rendering.TextureType;
 
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import team.chisel.ctmlib.ISubmapManager;
@@ -88,9 +89,8 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
         }
     }
 
-    @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal = ThreadLocal
-        .withInitial(RenderBlocksVoidstone::new);
+    private static final ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal = FMLLaunchHandler.side()
+        .isClient() ? ThreadLocal.withInitial(RenderBlocksVoidstone::new) : null;
 
     private ISubmapManager overlay;
     private static TextureSubmap base;

--- a/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
+++ b/src/main/java/team/chisel/client/render/SubmapManagerVoidstone.java
@@ -89,7 +89,8 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
     }
 
     @SideOnly(Side.CLIENT)
-    private static ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal;
+    private static ThreadLocal<RenderBlocksVoidstone> renderBlocksThreadLocal = ThreadLocal
+        .withInitial(RenderBlocksVoidstone::new);
 
     private ISubmapManager overlay;
     private static TextureSubmap base;
@@ -123,10 +124,6 @@ public class SubmapManagerVoidstone extends SubmapManagerBase {
     @Override
     @SideOnly(Side.CLIENT)
     public RenderBlocks createRenderContext(RenderBlocks rendererOld, Block block, IBlockAccess world) {
-        if (renderBlocksThreadLocal == null) {
-            renderBlocksThreadLocal = ThreadLocal.withInitial(RenderBlocksVoidstone::new);
-        }
-
         RenderBlocksVoidstone rb = renderBlocksThreadLocal.get();
         RenderBlocks ctx = overlay.createRenderContext(rendererOld, block, world);
         rb.setRenderBoundsFromBlock(block);

--- a/src/main/java/team/chisel/client/render/tile/RenderCarvableBeacon.java
+++ b/src/main/java/team/chisel/client/render/tile/RenderCarvableBeacon.java
@@ -26,7 +26,7 @@ public class RenderCarvableBeacon extends TileEntityBeaconRenderer implements IS
 
     private static final ResourceLocation texture = new ResourceLocation("textures/entity/beacon_beam.png");
 
-    private int renderId;
+    private final int renderId;
 
     public RenderCarvableBeacon() {
         this.renderId = RenderingRegistry.getNextAvailableRenderId();

--- a/src/main/java/team/chisel/ctmlib/CTMRenderer.java
+++ b/src/main/java/team/chisel/ctmlib/CTMRenderer.java
@@ -90,7 +90,6 @@ public class CTMRenderer implements ISimpleBlockRenderingHandler {
                 }
                 if (rb instanceof RenderBlocksCTM rbctm) {
                     rbctm.manager = rbctm.manager == null ? manager : rbctm.manager;
-                    rbctm.rendererOld = rbctm.rendererOld == null ? rendererOld : rbctm.rendererOld;
                 }
                 return rb;
             }

--- a/src/main/java/team/chisel/ctmlib/CTMRenderer.java
+++ b/src/main/java/team/chisel/ctmlib/CTMRenderer.java
@@ -78,8 +78,7 @@ public class CTMRenderer implements ISimpleBlockRenderingHandler {
                         rendererOld.renderMaxY,
                         rendererOld.renderMaxZ);
                 }
-                if (rb instanceof RenderBlocksCTM) {
-                    RenderBlocksCTM rbctm = (RenderBlocksCTM) rb;
+                if (rb instanceof RenderBlocksCTM rbctm) {
                     rbctm.manager = rbctm.manager == null ? manager : rbctm.manager;
                     rbctm.rendererOld = rbctm.rendererOld == null ? rendererOld : rbctm.rendererOld;
                 }

--- a/src/main/java/team/chisel/ctmlib/CTMRenderer.java
+++ b/src/main/java/team/chisel/ctmlib/CTMRenderer.java
@@ -2,6 +2,7 @@ package team.chisel.ctmlib;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.CrashReportCategory;
@@ -27,29 +28,38 @@ public class CTMRenderer implements ISimpleBlockRenderingHandler {
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelID, RenderBlocks renderer) {
         GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
-        RenderBlocks rb = getContext(
-            renderer,
-            block,
-            Minecraft.getMinecraft().theWorld,
-            ((ICTMBlock<?>) block).getManager(metadata),
-            metadata);
-        Drawing.drawBlock(block, metadata, rb);
-        GL11.glTranslatef(0.5F, 0.5F, 0.5F);
-        rb.unlockBlockBounds();
+        final WorldClient world = Minecraft.getMinecraft().theWorld;
+        final RenderBlocks rb = getContext(renderer, block, world, ((ICTMBlock<?>) block).getManager(metadata));
+        boolean clean = false;
+        if (rb.blockAccess == null) {
+            rb.blockAccess = world;
+            clean = true;
+        }
+        try {
+            Drawing.drawBlock(block, metadata, rb);
+            GL11.glTranslatef(0.5F, 0.5F, 0.5F);
+            rb.unlockBlockBounds();
+        } finally {
+            if (clean) rb.blockAccess = null;
+        }
     }
 
     @Override
     public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId,
-        RenderBlocks rendererOld) {
+        RenderBlocks renderer) {
+        final int meta = world.getBlockMetadata(x, y, z);
+        final RenderBlocks rb = getContext(
+            renderer,
+            block,
+            world,
+            ((ICTMBlock<?>) block).getManager(world, x, y, z, meta));
+        boolean clean = false;
+        if (rb.blockAccess == null) {
+            rb.blockAccess = world;
+            clean = true;
+        }
         try {
-            int meta = world.getBlockMetadata(x, y, z);
-            RenderBlocks rb = getContext(
-                rendererOld,
-                block,
-                world,
-                ((ICTMBlock<?>) block).getManager(world, x, y, z, meta),
-                meta);
-            rb.renderAllFaces = rendererOld.renderAllFaces;
+            rb.renderAllFaces = renderer.renderAllFaces;
             boolean ret = rb.renderStandardBlock(block, x, y, z);
             rb.unlockBlockBounds();
             rb.renderAllFaces = false;
@@ -60,15 +70,15 @@ public class CTMRenderer implements ISimpleBlockRenderingHandler {
             crashreportcategory.addCrashSection("Block name", GameRegistry.findUniqueIdentifierFor(block));
             crashreportcategory.addCrashSection("Block metadata", world.getBlockMetadata(x, y, z));
             throw new ReportedException(crashreport);
+        } finally {
+            if (clean) rb.blockAccess = null;
         }
     }
 
-    protected RenderBlocks getContext(RenderBlocks rendererOld, Block block, IBlockAccess world, ISubmapManager manager,
-        int meta) {
+    private RenderBlocks getContext(RenderBlocks rendererOld, Block block, IBlockAccess world, ISubmapManager manager) {
         if (!rendererOld.hasOverrideBlockTexture() && manager != null) {
             RenderBlocks rb = manager.createRenderContext(rendererOld, block, world);
             if (rb != null && rb != rendererOld) {
-                rb.blockAccess = world;
                 if (rendererOld.lockBlockBounds) {
                     rb.overrideBlockBounds(
                         rendererOld.renderMinX,

--- a/src/main/java/team/chisel/ctmlib/RenderBlocksCTM.java
+++ b/src/main/java/team/chisel/ctmlib/RenderBlocksCTM.java
@@ -235,7 +235,6 @@ public class RenderBlocksCTM extends RenderBlocks {
     protected float[] bluCache = new float[4];
     public TextureSubmap submap;
     public TextureSubmap submapSmall;
-    public RenderBlocks rendererOld;
     public ISubmapManager manager;
 
     protected int[][] lightmap = new int[3][3];
@@ -258,9 +257,6 @@ public class RenderBlocksCTM extends RenderBlocks {
 
         tessellator.setColorOpaque_F(1.0F, 1.0F, 1.0F);
         tessellator.addTranslation(x, y, z);
-        if (rendererOld != null && rendererOld.hasOverrideBlockTexture()) {
-            setOverrideBlockTexture(rendererOld.overrideBlockTexture);
-        }
         inWorld = true;
         boolean res = super.renderStandardBlock(block, x, y, z);
         inWorld = false;

--- a/src/main/java/team/chisel/ctmlib/RenderBlocksCTM.java
+++ b/src/main/java/team/chisel/ctmlib/RenderBlocksCTM.java
@@ -102,15 +102,13 @@ public class RenderBlocksCTM extends RenderBlocks {
 		XZ_HALF_Y(0.5, 1, 0.5);
 		// @formatter:on
 
-        private double x, y, z;
+        private final double x, y, z;
 
-        private Vert(double x, double y, double z) {
+        Vert(double x, double y, double z) {
             this.x = x;
             this.y = y;
             this.z = z;
         }
-
-        private static double u, v, xDiff, yDiff, zDiff, uDiff, vDiff;
 
         void render(RenderBlocksCTM inst, ForgeDirection normal, int cacheID) {
             final Tessellator tessellator = Tessellator.instance;
@@ -120,12 +118,15 @@ public class RenderBlocksCTM extends RenderBlocks {
                 tessellator.setBrightness(inst.lightingCache[cacheID]);
             }
 
-            u = cacheID == 1 || cacheID == 2 ? inst.maxU : inst.minU;
-            v = cacheID < 2 ? inst.maxV : inst.minV;
+            double u = cacheID == 1 || cacheID == 2 ? inst.maxU : inst.minU;
+            double v = cacheID < 2 ? inst.maxV : inst.minV;
 
-            uDiff = inst.maxU - inst.minU;
-            vDiff = inst.maxV - inst.minV;
+            double uDiff = inst.maxU - inst.minU;
+            double vDiff = inst.maxV - inst.minV;
 
+            double xDiff;
+            double yDiff;
+            double zDiff;
             if (inst.renderMinX + inst.renderMinY + inst.renderMinZ != 0
                 || inst.renderMaxX + inst.renderMaxY + inst.renderMaxZ != 3) {
                 boolean uMin = u == inst.minU;
@@ -178,8 +179,8 @@ public class RenderBlocksCTM extends RenderBlocks {
 		YNEG_LB(ZERO, X_HALF, XZ_HALF, Z_HALF), YNEG_RB(X_HALF, X, Z_HALF_X, XZ_HALF), YNEG_RT(XZ_HALF, Z_HALF_X, XZ, X_HALF_Z), YNEG_LT(Z_HALF, XZ_HALF, X_HALF_Z, Z),
 		YPOS_LB(YZ, X_HALF_YZ, XZ_HALF_Y, Z_HALF_Y), YPOS_RB(X_HALF_YZ, XYZ, Z_HALF_XY, XZ_HALF_Y), YPOS_RT(XZ_HALF_Y, Z_HALF_XY, XY, X_HALF_Y), YPOS_LT(Z_HALF_Y, XZ_HALF_Y, X_HALF_Y, Y);
 		// @formatter:on
-        private Vert xmin, xmax, ymin, ymax;
-        private ForgeDirection normal;
+        private final Vert xmin, xmax, ymin, ymax;
+        private final ForgeDirection normal;
 
         SubSide(Vert xmin, Vert ymin, Vert ymax, Vert xmax) {
             this.xmin = xmin;
@@ -447,7 +448,7 @@ public class RenderBlocksCTM extends RenderBlocks {
         if (!inWorld || submap == null) {
             super.renderFaceXNeg(block, 0, 0, 0, icon);
         } else {
-            int tex[] = ctm.getSubmapIndices(blockAccess, bx, by, bz, 4);
+            int[] tex = ctm.getSubmapIndices(blockAccess, bx, by, bz, 4);
 
             fillLightmap(brightnessBottomRight, brightnessTopRight, brightnessTopLeft, brightnessBottomLeft);
             fillColormap(colorRedBottomRight, colorRedTopRight, colorRedTopLeft, colorRedBottomLeft, redmap);
@@ -472,7 +473,7 @@ public class RenderBlocksCTM extends RenderBlocks {
         if (!inWorld || submap == null) {
             super.renderFaceXPos(block, 0, 0, 0, icon);
         } else {
-            int tex[] = ctm.getSubmapIndices(blockAccess, bx, by, bz, 5);
+            int[] tex = ctm.getSubmapIndices(blockAccess, bx, by, bz, 5);
 
             fillLightmap(brightnessTopLeft, brightnessBottomLeft, brightnessBottomRight, brightnessTopRight);
             fillColormap(colorRedTopLeft, colorRedBottomLeft, colorRedBottomRight, colorRedTopRight, redmap);
@@ -497,7 +498,7 @@ public class RenderBlocksCTM extends RenderBlocks {
         if (!inWorld || submap == null) {
             super.renderFaceZNeg(block, 0, 0, 0, icon);
         } else {
-            int tex[] = ctm.getSubmapIndices(blockAccess, bx, by, bz, 2);
+            int[] tex = ctm.getSubmapIndices(blockAccess, bx, by, bz, 2);
 
             fillLightmap(brightnessBottomRight, brightnessTopRight, brightnessTopLeft, brightnessBottomLeft);
             fillColormap(colorRedBottomRight, colorRedTopRight, colorRedTopLeft, colorRedBottomLeft, redmap);
@@ -522,7 +523,7 @@ public class RenderBlocksCTM extends RenderBlocks {
         if (!inWorld || submap == null) {
             super.renderFaceZPos(block, 0, 0, 0, icon);
         } else {
-            int tex[] = ctm.getSubmapIndices(blockAccess, bx, by, bz, 3);
+            int[] tex = ctm.getSubmapIndices(blockAccess, bx, by, bz, 3);
 
             fillLightmap(brightnessBottomLeft, brightnessBottomRight, brightnessTopRight, brightnessTopLeft);
             fillColormap(colorRedBottomLeft, colorRedBottomRight, colorRedTopRight, colorRedTopLeft, redmap);
@@ -547,7 +548,7 @@ public class RenderBlocksCTM extends RenderBlocks {
         if (!inWorld || submap == null) {
             super.renderFaceYNeg(block, 0, 0, 0, icon);
         } else {
-            int tex[] = ctm.getSubmapIndices(blockAccess, bx, by, bz, 0);
+            int[] tex = ctm.getSubmapIndices(blockAccess, bx, by, bz, 0);
 
             fillLightmap(brightnessBottomLeft, brightnessBottomRight, brightnessTopRight, brightnessTopLeft);
             fillColormap(colorRedBottomLeft, colorRedBottomRight, colorRedTopRight, colorRedTopLeft, redmap);
@@ -572,7 +573,7 @@ public class RenderBlocksCTM extends RenderBlocks {
         if (!inWorld || submap == null) {
             super.renderFaceYPos(block, 0, 0, 0, icon);
         } else {
-            int tex[] = ctm.getSubmapIndices(blockAccess, bx, by, bz, 1);
+            int[] tex = ctm.getSubmapIndices(blockAccess, bx, by, bz, 1);
 
             fillLightmap(brightnessTopRight, brightnessTopLeft, brightnessBottomLeft, brightnessBottomRight);
             fillColormap(colorRedTopRight, colorRedTopLeft, colorRedBottomLeft, colorRedBottomRight, redmap);

--- a/src/main/java/team/chisel/ctmlib/RenderBlocksColumn.java
+++ b/src/main/java/team/chisel/ctmlib/RenderBlocksColumn.java
@@ -16,8 +16,8 @@ public class RenderBlocksColumn extends RenderBlocks {
     public IIcon iconTop;
     private boolean inWorld;
 
-    private IIcon sides[] = new IIcon[6];
-    private CTM ctm = CTM.getInstance();
+    private final IIcon[] sides = new IIcon[6];
+    private final CTM ctm = CTM.getInstance();
 
     public RenderBlocksColumn() {
         super();

--- a/src/main/java/team/chisel/item/chisel/ChiselController.java
+++ b/src/main/java/team/chisel/item/chisel/ChiselController.java
@@ -11,14 +11,12 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
-import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.cricketcraft.chisel.api.IChiselItem;
 import com.cricketcraft.chisel.api.carving.ICarvingGroup;
 import com.cricketcraft.chisel.api.carving.ICarvingVariation;
 import com.cricketcraft.chisel.api.carving.IChiselMode;
-import com.cricketcraft.chisel.api.rendering.TextureType;
 import com.google.common.collect.Queues;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -33,11 +31,10 @@ public final class ChiselController {
 
     protected static class GuiOpen implements Runnable {
 
-        private EntityPlayer player;
-        private ItemStack stack;
+        private final EntityPlayer player;
+        private final ItemStack stack;
 
         public GuiOpen(EntityPlayer player, ItemStack stack) {
-            super();
             this.player = player;
             this.stack = stack;
         }
@@ -55,7 +52,7 @@ public final class ChiselController {
 
     public static final ChiselController INSTANCE = new ChiselController();
 
-    Queue<GuiOpen> openQueue = Queues.newArrayDeque();
+    final Queue<GuiOpen> openQueue = Queues.newArrayDeque();
 
     private ChiselController() {}
 
@@ -160,13 +157,6 @@ public final class ChiselController {
             if (open != null) {
                 open.run();
             }
-        }
-    }
-
-    @SubscribeEvent
-    public void onWorldUnload(WorldEvent.Unload event) {
-        if (event.world.isRemote) {
-            TextureType.clearStatics();
         }
     }
 


### PR DESCRIPTION
The actual fix is like 10 lines of code in `CTMRenderer` by just adding a `try/finally`, the rest is some code cleanup.

I also deleted the rendererOld field because it was leaking the world, its existance looks cursed and after deletion I couldn't see anything wrong in the rendering.

<img width="432" height="141" alt="image" src="https://github.com/user-attachments/assets/fbcc99e1-2370-49a6-9464-8df5557ef04c" />
<img width="651" height="141" alt="image" src="https://github.com/user-attachments/assets/bbf13ff6-7554-4726-a15d-de2f7266731a" />
<img width="433" height="123" alt="image" src="https://github.com/user-attachments/assets/9c2c407f-441f-4837-9c44-29e42949a001" />
<img width="636" height="223" alt="image" src="https://github.com/user-attachments/assets/e3164b86-7c1b-4db6-a79d-2d80cfd571ea" />
