### PR TITLE
ItemChisel: Set max damage field instead of overriding getMaxDamage

### DIFF
--- a/src/main/java/team/chisel/item/chisel/ItemChisel.java
+++ b/src/main/java/team/chisel/item/chisel/ItemChisel.java
@@ -51,6 +51,7 @@ public class ItemChisel extends Item implements IChiselItem {
         super();
         this.type = type;
         setMaxStackSize(1);
+        setMaxDamage(Configurations.allowChiselDamage ? type.maxDamage : 0);
         setTextureName(
             Chisel.MOD_ID + ":chisel_"
                 + type.name()
@@ -67,12 +68,6 @@ public class ItemChisel extends Item implements IChiselItem {
                     + type.name()
                         .toLowerCase());
         }
-    }
-
-    @Override
-    public int getMaxDamage(ItemStack stack) {
-        if (Configurations.allowChiselDamage) return type.maxDamage;
-        return 0;
     }
 
     @Override


### PR DESCRIPTION
Not really sure why the `getMaxDamage(ItemStack)` method was overriden instead of just calling `setMaxDamage`. Some methods call `getMaxDamage()` which would always return 0. This caused combining two chisels to lose durability instead of repairing them as that recipe called `getMaxDamage` without the ItemStack. Might fix other issues? Hopefully doesn't break something that relied on the method returning 0?

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23793