### PR TITLE
Add concrete slabs and stairs

### DIFF
--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -37,6 +37,7 @@ import team.chisel.block.BlockCarvable;
 import team.chisel.block.BlockCarvableBeacon;
 import team.chisel.block.BlockCarvableBookshelf;
 import team.chisel.block.BlockCarvableCarpet;
+import team.chisel.block.BlockCarvableConcreteSlab;
 import team.chisel.block.BlockCarvableGlass;
 import team.chisel.block.BlockCarvableGlow;
 import team.chisel.block.BlockCarvableGlowie;
@@ -844,6 +845,26 @@ public enum Features {
             concrete.carverHelper.registerAll(concrete, "concrete");
             OreDictionary.registerOre("concrete", concrete);
             Carving.chisel.registerOre("concrete", "concrete");
+
+            BlockCarvableSlab concrete_slab = (BlockCarvableSlab) new BlockCarvableConcreteSlab(concrete)
+                .setStepSound(Block.soundTypeStone)
+                .setCreativeTab(ChiselTabs.tabStoneChiselBlocks)
+                .setHardness(0.5F);
+
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.0.desc", 0, "concrete/default");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.1.desc", 1, "concreteslab/block");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.2.desc", 2, "concreteslab/doubleslab");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.3.desc", 3, "concreteslab/blocks");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.4.desc", 4, "concreteslab/weathered");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.5.desc", 5, "concreteslab/weathered-block");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.6.desc", 6, "concreteslab/weathered-doubleslab");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.7.desc", 7, "concreteslab/weathered-blocks");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.8.desc", 8, "concreteslab/weathered-half");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.9.desc", 9, "concreteslab/weathered-block-half");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.10.desc", 10, "concreteslab/asphalt");
+            concrete_slab.carverHelper.registerAll(concrete_slab, "concrete_slab", ItemCarvableSlab.class);
+            registerSlabTop(concrete_slab, concrete_slab.top);
+            Carving.chisel.registerOre("concrete_slab", "concrete_slab");
         }
 
         @Override
@@ -859,6 +880,12 @@ public enum Features {
 
             FurnaceRecipes.smelting()
                 .func_151393_a(concreteRecipeBlock, new ItemStack(concrete), 0.1F);
+
+            GameRegistry.addRecipe(
+                new ItemStack(concrete_slab, 6, 0),
+                "***",
+                '*',
+                new ItemStack(concrete, 1, OreDictionary.WILDCARD_VALUE));
         }
     },
 

--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -38,6 +38,7 @@ import team.chisel.block.BlockCarvableBeacon;
 import team.chisel.block.BlockCarvableBookshelf;
 import team.chisel.block.BlockCarvableCarpet;
 import team.chisel.block.BlockCarvableConcreteSlab;
+import team.chisel.block.BlockCarvableConcreteStairs;
 import team.chisel.block.BlockCarvableGlass;
 import team.chisel.block.BlockCarvableGlow;
 import team.chisel.block.BlockCarvableGlowie;
@@ -865,6 +866,30 @@ public enum Features {
             concrete_slab.carverHelper.registerAll(concrete_slab, "concrete_slab", ItemCarvableSlab.class);
             registerSlabTop(concrete_slab, concrete_slab.top);
             Carving.chisel.registerOre("concrete_slab", "concrete_slab");
+
+            CarvableStairsMaker makerConcreteStairs = new CarvableStairsMaker(concrete);
+
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.0.desc", 0, "concrete/default");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.1.desc", 1, "concrete/block");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.2.desc", 2, "concrete/doubleslab");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.3.desc", 3, "concrete/blocks");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.4.desc", 4, "concrete/weathered");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.5.desc", 5, "concrete/weathered-block");
+            makerConcreteStairs.carverHelper
+                .addVariation("tile.concreteStairs.6.desc", 6, "concrete/weathered-doubleslab");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.7.desc", 7, "concrete/weathered-blocks");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.8.desc", 8, "concrete/weathered-half");
+            makerConcreteStairs.carverHelper
+                .addVariation("tile.concreteStairs.9.desc", 9, "concrete/weathered-block-half");
+            makerConcreteStairs.carverHelper.addVariation("tile.concreteStairs.10.desc", 10, "concrete/asphalt");
+            makerConcreteStairs.create(new IStairsCreator() {
+
+                @Override
+                public BlockCarvableStairs create(Block block, int meta, CarvableHelper helper) {
+                    return new BlockCarvableConcreteStairs(block, meta, helper);
+                }
+            }, "concrete_stairs", concreteStairs);
+            Carving.chisel.registerOre("concrete_stairs", "concrete_stairs");
         }
 
         @Override

--- a/src/main/java/team/chisel/Features.java
+++ b/src/main/java/team/chisel/Features.java
@@ -853,16 +853,16 @@ public enum Features {
                 .setHardness(0.5F);
 
             concrete_slab.carverHelper.addVariation("tile.concreteSlab.0.desc", 0, "concrete/default");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.1.desc", 1, "concreteslab/block");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.2.desc", 2, "concreteslab/doubleslab");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.3.desc", 3, "concreteslab/blocks");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.4.desc", 4, "concreteslab/weathered");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.5.desc", 5, "concreteslab/weathered-block");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.6.desc", 6, "concreteslab/weathered-doubleslab");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.7.desc", 7, "concreteslab/weathered-blocks");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.8.desc", 8, "concreteslab/weathered-half");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.9.desc", 9, "concreteslab/weathered-block-half");
-            concrete_slab.carverHelper.addVariation("tile.concreteSlab.10.desc", 10, "concreteslab/asphalt");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.1.desc", 1, "concrete/block");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.2.desc", 2, "concrete/doubleslab");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.3.desc", 3, "concrete/blocks");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.4.desc", 4, "concrete/weathered");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.5.desc", 5, "concrete/weathered-block");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.6.desc", 6, "concrete/weathered-doubleslab");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.7.desc", 7, "concrete/weathered-blocks");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.8.desc", 8, "concrete/weathered-half");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.9.desc", 9, "concrete/weathered-block-half");
+            concrete_slab.carverHelper.addVariation("tile.concreteSlab.10.desc", 10, "concrete/asphalt");
             concrete_slab.carverHelper.registerAll(concrete_slab, "concrete_slab", ItemCarvableSlab.class);
             registerSlabTop(concrete_slab, concrete_slab.top);
             Carving.chisel.registerOre("concrete_slab", "concrete_slab");

--- a/src/main/java/team/chisel/block/BlockCarvableConcreteSlab.java
+++ b/src/main/java/team/chisel/block/BlockCarvableConcreteSlab.java
@@ -53,18 +53,7 @@ public class BlockCarvableConcreteSlab extends BlockCarvableSlab {
                     MathHelper.floor_double(player.posY) - 2,
                     MathHelper.floor_double(player.posZ));
 
-                // Test class type
-//                if (below == BlockCarvableConcreteSlab.this) {
-//                    FMLLog.getLogger().info(player.worldObj.getBlock(
-//                        MathHelper.floor_double(player.posX) + 2,
-//                        MathHelper.floor_double(player.posY) - 2,
-//                        MathHelper.floor_double(player.posZ))
-//                    );
-//                }
-
                 if (below == BlockCarvableConcreteSlab.this) {
-                    //FMLLog.getLogger().info("Player at {}, Block below {} is at y={}",
-                    //    MathHelper.floor_double(player.posY), below, MathHelper.floor_double(player.posY) - 2);
                     manualInputCheck.updatePlayerMoveState();
                     if (manualInputCheck.moveForward != 0 || manualInputCheck.moveStrafe != 0) {
                         player.motionX *= Configurations.concreteVelocityMult + 0.05;

--- a/src/main/java/team/chisel/block/BlockCarvableConcreteSlab.java
+++ b/src/main/java/team/chisel/block/BlockCarvableConcreteSlab.java
@@ -1,0 +1,57 @@
+package team.chisel.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.MovementInput;
+import net.minecraft.util.MovementInputFromOptions;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent.Phase;
+import cpw.mods.fml.common.gameevent.TickEvent.PlayerTickEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import team.chisel.config.Configurations;
+
+public class BlockCarvableConcreteSlab extends BlockCarvableSlab {
+
+    public BlockCarvableConcreteSlab(Block block) {
+        super((BlockCarvable) block);
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new EventHandler());
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static MovementInput manualInputCheck;
+
+    public class EventHandler {
+
+        @SubscribeEvent
+        @SideOnly(Side.CLIENT)
+        public void speedupPlayer(PlayerTickEvent event) {
+            if (event.phase == Phase.START && event.side.isClient()
+                && event.player.onGround
+                && event.player instanceof EntityPlayerSP) {
+                if (manualInputCheck == null) {
+                    manualInputCheck = new MovementInputFromOptions(Minecraft.getMinecraft().gameSettings);
+                }
+                EntityPlayerSP player = (EntityPlayerSP) event.player;
+                Block below = player.worldObj.getBlock(
+                    MathHelper.floor_double(player.posX),
+                    MathHelper.floor_double(player.posY) - 2,
+                    MathHelper.floor_double(player.posZ));
+                if (below == BlockCarvableConcreteSlab.this) {
+                    manualInputCheck.updatePlayerMoveState();
+                    if (manualInputCheck.moveForward != 0 || manualInputCheck.moveStrafe != 0) {
+                        player.motionX *= Configurations.concreteVelocityMult + 0.05;
+                        player.motionZ *= Configurations.concreteVelocityMult + 0.05;
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/team/chisel/block/BlockCarvableConcreteSlab.java
+++ b/src/main/java/team/chisel/block/BlockCarvableConcreteSlab.java
@@ -17,8 +17,17 @@ import team.chisel.config.Configurations;
 
 public class BlockCarvableConcreteSlab extends BlockCarvableSlab {
 
-    public BlockCarvableConcreteSlab(Block block) {
-        super((BlockCarvable) block);
+    public BlockCarvableConcreteSlab(BlockCarvable block) {
+        super(block);
+        top = new BlockCarvableConcreteSlab(this);
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new EventHandler());
+    }
+
+    // Constructor to get concrete top slabs to work
+    public BlockCarvableConcreteSlab(BlockCarvableSlab bottomBlock) {
+        super(bottomBlock);
         FMLCommonHandler.instance()
             .bus()
             .register(new EventHandler());
@@ -43,7 +52,19 @@ public class BlockCarvableConcreteSlab extends BlockCarvableSlab {
                     MathHelper.floor_double(player.posX),
                     MathHelper.floor_double(player.posY) - 2,
                     MathHelper.floor_double(player.posZ));
+
+                // Test class type
+//                if (below == BlockCarvableConcreteSlab.this) {
+//                    FMLLog.getLogger().info(player.worldObj.getBlock(
+//                        MathHelper.floor_double(player.posX) + 2,
+//                        MathHelper.floor_double(player.posY) - 2,
+//                        MathHelper.floor_double(player.posZ))
+//                    );
+//                }
+
                 if (below == BlockCarvableConcreteSlab.this) {
+                    //FMLLog.getLogger().info("Player at {}, Block below {} is at y={}",
+                    //    MathHelper.floor_double(player.posY), below, MathHelper.floor_double(player.posY) - 2);
                     manualInputCheck.updatePlayerMoveState();
                     if (manualInputCheck.moveForward != 0 || manualInputCheck.moveStrafe != 0) {
                         player.motionX *= Configurations.concreteVelocityMult + 0.05;

--- a/src/main/java/team/chisel/block/BlockCarvableConcreteStairs.java
+++ b/src/main/java/team/chisel/block/BlockCarvableConcreteStairs.java
@@ -1,0 +1,79 @@
+package team.chisel.block;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.MovementInput;
+import net.minecraft.util.MovementInputFromOptions;
+
+import com.cricketcraft.chisel.api.carving.CarvableHelper;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import team.chisel.config.Configurations;
+
+public class BlockCarvableConcreteStairs extends BlockCarvableStairs {
+
+    public BlockCarvableConcreteStairs(Block block, int meta, CarvableHelper helper) {
+        super(block, meta, helper);
+
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new EventHandler());
+    }
+
+    // Override super's getSubBlocks to allow concrete's 11 variants
+    // Stairs are added to the list in pairs, so odd-numbered variant counts create
+    // a block that shouldn't exist. This modification makes the block unreachable by normal
+    // means (NEI, creative menu), but still technically exists in-game
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public void getSubBlocks(Item block, CreativeTabs tabs, List list) {
+        list.add(new ItemStack(block, 1, 0));
+
+        // If odd# of variations && meta for the current block == variation.size - 1, exit
+        // Second check checks if the current block is at the end of the variation list
+        if (carverHelper.infoList.size() % 2 == 1 && this.blockMeta == carverHelper.infoList.size() - 1) return;
+        list.add(new ItemStack(block, 1, 8));
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static MovementInput manualInputCheck;
+
+    public class EventHandler {
+
+        @SubscribeEvent
+        @SideOnly(Side.CLIENT)
+        public void speedupPlayer(TickEvent.PlayerTickEvent event) {
+            if (event.phase == TickEvent.Phase.START && event.side.isClient()
+                && event.player.onGround
+                && event.player instanceof EntityPlayerSP) {
+                if (manualInputCheck == null) {
+                    manualInputCheck = new MovementInputFromOptions(Minecraft.getMinecraft().gameSettings);
+                }
+                EntityPlayerSP player = (EntityPlayerSP) event.player;
+                Block below = player.worldObj.getBlock(
+                    MathHelper.floor_double(player.posX),
+                    MathHelper.floor_double(player.posY) - 2,
+                    MathHelper.floor_double(player.posZ));
+
+                if (below == BlockCarvableConcreteStairs.this) {
+                    manualInputCheck.updatePlayerMoveState();
+                    if (manualInputCheck.moveForward != 0 || manualInputCheck.moveStrafe != 0) {
+                        player.motionX *= Configurations.concreteVelocityMult + 0.05;
+                        player.motionZ *= Configurations.concreteVelocityMult + 0.05;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/team/chisel/compat/nei/NEIChiselConfig.java
+++ b/src/main/java/team/chisel/compat/nei/NEIChiselConfig.java
@@ -25,6 +25,7 @@ public class NEIChiselConfig implements IConfigureNEI {
         API.hideItem(new ItemStack(GameRegistry.findBlock("chisel", "limestone_slab_top")));
         API.hideItem(new ItemStack(GameRegistry.findBlock("chisel", "marble_slab_top")));
         API.hideItem(new ItemStack(GameRegistry.findBlock("chisel", "marble_pillar_slab_top")));
+        API.hideItem(new ItemStack(GameRegistry.findBlock("chisel", "concrete_slab_top")));
 
         RecipeHandlerChisel handler = new RecipeHandlerChisel();
         API.registerRecipeHandler(handler);

--- a/src/main/java/team/chisel/init/ChiselBlocks.java
+++ b/src/main/java/team/chisel/init/ChiselBlocks.java
@@ -53,6 +53,7 @@ public final class ChiselBlocks {
     public static final BlockCarvable sandstone = null;
     public static final BlockCarvable sandstone_scribbles = null;
     public static final BlockConcrete concrete = null;
+    public static final BlockCarvableSlab concrete_slab = null;
     public static final BlockRoadLine road_line = null;
     public static final BlockCarvable iron_block = null;
     public static final BlockCarvable gold_block = null;

--- a/src/main/java/team/chisel/init/ChiselBlocks.java
+++ b/src/main/java/team/chisel/init/ChiselBlocks.java
@@ -7,6 +7,8 @@ import team.chisel.Chisel;
 import team.chisel.block.BlockCarvable;
 import team.chisel.block.BlockCarvableBeacon;
 import team.chisel.block.BlockCarvableCarpet;
+import team.chisel.block.BlockCarvableConcreteSlab;
+import team.chisel.block.BlockCarvableConcreteStairs;
 import team.chisel.block.BlockCarvableGlass;
 import team.chisel.block.BlockCarvableGlowstone;
 import team.chisel.block.BlockCarvableIce;
@@ -53,7 +55,7 @@ public final class ChiselBlocks {
     public static final BlockCarvable sandstone = null;
     public static final BlockCarvable sandstone_scribbles = null;
     public static final BlockConcrete concrete = null;
-    public static final BlockCarvableSlab concrete_slab = null;
+    public static final BlockCarvableConcreteSlab concrete_slab = null;
     public static final BlockRoadLine road_line = null;
     public static final BlockCarvable iron_block = null;
     public static final BlockCarvable gold_block = null;
@@ -148,6 +150,7 @@ public final class ChiselBlocks {
     public static BlockCarvableStairs[] limestoneStairs = new BlockCarvableStairs[8];
     public static BlockCarvableIceStairs[] iceStairs = new BlockCarvableIceStairs[8];
     public static BlockCarvablePackedIceStairs[] packediceStairs = new BlockCarvablePackedIceStairs[8];
+    public static BlockCarvableConcreteStairs[] concreteStairs = new BlockCarvableConcreteStairs[6];
 
     public static Block[] torches = new BlockCarvableTorch[16];
 

--- a/src/main/resources/assets/chisel/lang/en_US.lang
+++ b/src/main/resources/assets/chisel/lang/en_US.lang
@@ -1293,6 +1293,20 @@ tile.concrete.8.desc=Partly Weathered Concrete
 tile.concrete.9.desc=Partly Weathered Concrete Block
 tile.concrete.10.desc=Asphalt
 
+#Concrete Slabs
+tile.chisel.concrete_slab.name=Concrete Slab
+tile.concreteSlab.0.desc=Concrete Slab
+tile.concreteSlab.1.desc=Concrete Block Slab
+tile.concreteSlab.2.desc=Concrete Double Slab
+tile.concreteSlab.3.desc=Small Concrete Block Slab
+tile.concreteSlab.4.desc=Weathered Concrete Slab
+tile.concreteSlab.5.desc=Weathered Concrete Block Slab
+tile.concreteSlab.6.desc=Weathered Concrete Double Slab
+tile.concreteSlab.7.desc=Small Weathered Blocks Slab
+tile.concreteSlab.8.desc=Partly Weathered Concrete Slab
+tile.concreteSlab.9.desc=Partly Weathered Concrete Block Slab
+tile.concreteSlab.10.desc=Asphalt
+
 # Road Line
 tile.chisel.road_line.name=Road Lines
 tile.roadLine.0.desc=White

--- a/src/main/resources/assets/chisel/lang/en_US.lang
+++ b/src/main/resources/assets/chisel/lang/en_US.lang
@@ -1302,10 +1302,34 @@ tile.concreteSlab.3.desc=Small Concrete Block Slab
 tile.concreteSlab.4.desc=Weathered Concrete Slab
 tile.concreteSlab.5.desc=Weathered Concrete Block Slab
 tile.concreteSlab.6.desc=Weathered Concrete Double Slab
-tile.concreteSlab.7.desc=Small Weathered Blocks Slab
+tile.concreteSlab.7.desc=Small Weathered Block Slab
 tile.concreteSlab.8.desc=Partly Weathered Concrete Slab
 tile.concreteSlab.9.desc=Partly Weathered Concrete Block Slab
 tile.concreteSlab.10.desc=Asphalt
+
+#Concrete Stairs
+#The same name goes here 8 different times since stairs take up 8 block positions.
+#Sorry!  It was the only way! Maybe one day it will be fixed...
+tile.chisel.concrete_stairs.0.name=Concrete Stairs
+tile.chisel.concrete_stairs.1.name=Concrete Stairs
+tile.chisel.concrete_stairs.2.name=Concrete Stairs
+tile.chisel.concrete_stairs.3.name=Concrete Stairs
+tile.chisel.concrete_stairs.4.name=Concrete Stairs
+tile.chisel.concrete_stairs.5.name=Concrete Stairs
+tile.chisel.concrete_stairs.6.name=Concrete Stairs
+tile.chisel.concrete_stairs.7.name=Concrete Stairs
+
+tile.concreteStairs.0.desc=Concrete Stairs
+tile.concreteStairs.1.desc=Concrete Block Stairs
+tile.concreteStairs.2.desc=Concrete Double Slab Stairs
+tile.concreteStairs.3.desc=Small Concrete Block Stairs
+tile.concreteStairs.4.desc=Weathered Concrete Stairs
+tile.concreteStairs.5.desc=Weathered Concrete Block Stairs
+tile.concreteStairs.6.desc=Weathered Concrete Double Slab Stairs
+tile.concreteStairs.7.desc=Small Weathered Block Stairs
+tile.concreteStairs.8.desc=Partly Weathered Concrete Stairs
+tile.concreteStairs.9.desc=Partly Weathered Concrete Block Stairs
+tile.concreteStairs.10.desc=Asphalt Stairs
 
 # Road Line
 tile.chisel.road_line.name=Road Lines


### PR DESCRIPTION
Add slabs and stairs to all of Chisel's concrete variants, complete with player walk speed increase. 

Currently both slabs and stairs are subclasses that directly copy/paste the speedup method from BlockConcrete, only changing the check for the block below the player. Might be able to consolidate this method somewhere else to reduce code duplication - I'll look into this some more if its desirable.

The new blocks also only have lang entries for en_us.lang, as that is the only language I know.

Closes GTNewHorizons/GT-New-Horizons-Modpack#24312

<img width="1241" height="567" alt="display_of_concrete_slabs_stairs" src="https://github.com/user-attachments/assets/43e54575-0818-42cb-afa0-40a41b1aa48e" />
